### PR TITLE
Fix/game gallery

### DIFF
--- a/frontend/src/components/GameGallery.js
+++ b/frontend/src/components/GameGallery.js
@@ -20,19 +20,62 @@ export default function GameGallery() {
 			"id": "snake-but-ducks",
 			"title": "Snake! but ducks",
 			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "duck-duck-go6",
+			"title": "duck duck go",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "go-duck4",
+			"title": "go duck",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "snake-but-ducks9",
+			"title": "Snake! but ducks",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "duck-duck-go1",
+			"title": "duck duck go",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "go-duck2",
+			"title": "go duck",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "snake-but-ducks3",
+			"title": "Snake! but ducks",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "duck-duck-go11",
+			"title": "duck duck go",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "go-duck21",
+			"title": "go duck",
+			"image": "./assets/placeholder.jpg"
+		},
+		{
+			"id": "snake-but-ducks31",
+			"title": "Snake! but ducks",
+			"image": "./assets/placeholder.jpg"
 		}
 	]
   
-  const [showFullGallery, setShowFullGallery] = useState(false);
+	const [showFullGallery, setShowFullGallery] = useState(false);
 
     const handleSeeAllClick = () => {
         setShowFullGallery(!showFullGallery);
     };
-
-	
 	
 	return (
-        <div className="game-gallery">
+        <div className={showFullGallery ? 'game-gallery wrap' : 'game-gallery'}>
             <div className="card" style={{ 'backgroundColor': '#e6e6e6' }}>
                 <button onClick={handleSeeAllClick}>
                     {showFullGallery ? 'Show Less' : 'See All'}
@@ -40,10 +83,18 @@ export default function GameGallery() {
             </div>
 
 			{showFullGallery
-				? games.map((game) => <div className="card" style={{ 'backgroundColor': '#e6e6e6' }}><GameThumbnail key={game}></GameThumbnail></div>)
-				: games.slice(0, 6).map((game) => <div className="card" style={{ 'backgroundColor': '#e6e6e6' }}><GameThumbnail key={game}></GameThumbnail></div>)
+				? games.map((game) => 
+					<div className="card" style={{ 'backgroundColor': '#e6e6e6' }}>
+						<GameThumbnail key={game}></GameThumbnail>
+					</div>
+				)
+				// TODO reserve for previous 6 games played
+				: games.slice(0, 6).map((game) => 
+					<div className="card" style={{ 'backgroundColor': '#e6e6e6' }}>
+						<GameThumbnail key={game}></GameThumbnail>
+					</div>
+				)
 			}
-            
         </div>
     );
 }

--- a/frontend/src/pages/GameGalleryPage.js
+++ b/frontend/src/pages/GameGalleryPage.js
@@ -1,7 +1,0 @@
-export default function GameGalleryPage () {
-	return (
-		<div>
-			This will be the page where the game gallery goes.
-		</div>
-	)
-}

--- a/frontend/src/styles/GameGallery.css
+++ b/frontend/src/styles/GameGallery.css
@@ -1,15 +1,19 @@
 .game-gallery {
     display: flex;
-    flex-wrap: wrap;
+    overflow-x: scroll;
     justify-content: flex-start;
     width: 100%;
     padding: 20px 0;
 }
 
-/* remove the scrollbar */
-::-webkit-scrollbar {
-    width: 0px;
+.wrap {
+    flex-wrap: wrap;
 }
+
+/* remove the scrollbar */
+/* ::-webkit-scrollbar {
+    width: 0px;
+} */
 
 .card {
     /* background-color: 'red'; */


### PR DESCRIPTION

# A/C
When the user clicks `See All` on the home screen, the initial limited horizontal Games view should be converted to a vertical view to show all of the games available

# Changes
I used Kasim's `showFullGallery` state to add conditional styling to the parent div of the game gallery.  The first 6 games shown will later be altered to include the top 6 recently played games.

Since the full vertical game gallery is shown within the `GameGallery` component, the `GameGalleryPage` has been deleted
