### PR TITLE
Fix/autostart

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,16 +18,14 @@ fn running_on_rasp_pi() -> bool {
 }
 
 fn main() {
-    let mut app = tauri::Builder::default();
-
-    app = app.plugin(tauri_plugin_autostart::init(
+    tauri::Builder::default()
+    .plugin(tauri_plugin_autostart::init(
         MacosLauncher::LaunchAgent,
         Some(vec![""]),
-    ));
-
-    app.setup(|app| {
+    ))
+    .setup(|app| {
         app.manage(Mutex::new(AppState::default()));
-        if running_on_rasp_pi() {
+        if running_on_rasp_pi() { // Only enable on raspberry pi
             app.autolaunch().enable()?;
         }
         Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use frontend_api::games::{get_game_info, AppState, play_game};
+use frontend_api::games::{get_game_info, play_game, AppState};
 use tauri::Manager;
 use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
@@ -9,21 +9,33 @@ use std::sync::Mutex;
 
 mod frontend_api;
 
+/// Returns true if the code is running on a raspberry pi
+fn running_on_rasp_pi() -> bool {
+    cfg!(all(
+        target_arch = "aarch64",
+        not(any(target_os = "macos", target_os = "linux"))
+    ))
+}
+
 fn main() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::LaunchAgent,
-            Some(vec![""]),
-        ))
-        .setup(|app| {
-            app.manage(Mutex::new(AppState::default()));
+    let mut app = tauri::Builder::default();
+
+    app = app.plugin(tauri_plugin_autostart::init(
+        MacosLauncher::LaunchAgent,
+        Some(vec![""]),
+    ));
+
+    app.setup(|app| {
+        app.manage(Mutex::new(AppState::default()));
+        if running_on_rasp_pi() {
             app.autolaunch().enable()?;
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![get_game_info, play_game])
-        .on_page_load(|window, _| {
-            window.show().expect("Failed to show window");
-        })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        }
+        Ok(())
+    })
+    .invoke_handler(tauri::generate_handler![get_game_info, play_game])
+    .on_page_load(|window, _| {
+        window.show().expect("Failed to show window");
+    })
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,21 +19,22 @@ fn running_on_rasp_pi() -> bool {
 
 fn main() {
     tauri::Builder::default()
-    .plugin(tauri_plugin_autostart::init(
-        MacosLauncher::LaunchAgent,
-        Some(vec![""]),
-    ))
-    .setup(|app| {
-        app.manage(Mutex::new(AppState::default()));
-        if running_on_rasp_pi() { // Only enable on raspberry pi
-            app.autolaunch().enable()?;
-        }
-        Ok(())
-    })
-    .invoke_handler(tauri::generate_handler![get_game_info, play_game])
-    .on_page_load(|window, _| {
-        window.show().expect("Failed to show window");
-    })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            Some(vec![""]),
+        ))
+        .setup(|app| {
+            app.manage(Mutex::new(AppState::default()));
+            if running_on_rasp_pi() {
+                // Only enable on raspberry pi
+                app.autolaunch().enable()?;
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![get_game_info, play_game])
+        .on_page_load(|window, _| {
+            window.show().expect("Failed to show window");
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }


### PR DESCRIPTION
Now, the Tauri auto-start plugin will only enable if the hardware running the code has aarch64 architecture and is neither Linux nor Windows. This should limit it to the Raspberry Pi we are using.