### PR TITLE
Make usernames unique

### DIFF
--- a/src-tauri/migrations/2025-02-21-211725_create_users/up.sql
+++ b/src-tauri/migrations/2025-02-21-211725_create_users/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
 CREATE TABLE users (
   id CHAR(32) NOT NULL PRIMARY KEY,
-  name TEXT NOT NULL,
+  username TEXT NOT NULL UNIQUE ,
   rit_id TEXT
 )

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -196,22 +196,22 @@ pub async fn get_save_data(
     }
 }
 
-pub async fn create_user(id_s: &str, name_s: &str, db_name: &str) -> User {
+pub async fn create_user(id_s: &str, username_s: &str, db_name: &str) -> User {
     use self::schema::users::dsl::*;
     let connection = &mut establish_connection(db_name);
     insert_into(users)
-        .values((id.eq(id_s), username.eq(name_s)))
+        .values((id.eq(id_s), username.eq(username_s)))
         .get_result::<User>(connection)
         .expect("Could not create User")
 }
 
-pub async fn get_user(name_s: &str, user_id_s: &str, db_name: &str) -> User {
+pub async fn get_user(username_s: &str, user_id_s: &str, db_name: &str) -> User {
     use self::schema::users::dsl::*;
     let connection = &mut establish_connection(db_name);
 
     users
         .select(User::as_select())
-        .filter(username.eq(name_s))
+        .filter(username.eq(username_s))
         .filter(id.eq(user_id_s))
         .first(connection)
         .expect("Error loading user data")

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -200,7 +200,7 @@ pub async fn create_user(id_s: &str, name_s: &str, db_name: &str) -> User {
     use self::schema::users::dsl::*;
     let connection = &mut establish_connection(db_name);
     insert_into(users)
-        .values((id.eq(id_s), name.eq(name_s)))
+        .values((id.eq(id_s), username.eq(name_s)))
         .get_result::<User>(connection)
         .expect("Could not create User")
 }
@@ -211,7 +211,7 @@ pub async fn get_user(name_s: &str, user_id_s: &str, db_name: &str) -> User {
 
     users
         .select(User::as_select())
-        .filter(name.eq(name_s))
+        .filter(username.eq(name_s))
         .filter(id.eq(user_id_s))
         .first(connection)
         .expect("Error loading user data")

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -18,7 +18,7 @@ pub struct LeaderboardEntry {
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct User {
     pub id: String,
-    pub name: String,
+    pub username: String,
     pub rit_id: Option<String>
 }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -31,7 +31,7 @@ diesel::table! {
 diesel::table! {
     users (id) {
         id -> Text,
-        name -> Text,
+        username -> Text,
         rit_id -> Nullable<Text>,
     }
 }

--- a/src-tauri/tests/integration_tests.rs
+++ b/src-tauri/tests/integration_tests.rs
@@ -17,18 +17,18 @@ async fn setup_initial_user_data(db_name: &str) {
     let users = vec![
         User {
             id: String::from("1"),
-            name: String::from("user0"),
+            username: String::from("user0"),
             rit_id: None,
         },
         User {
             id: String::from("2"),
-            name: String::from("user1"),
+            username: String::from("user1"),
             rit_id: None,
         },
     ];
 
     for user in users {
-        create_user(&user.id, &user.name, db_name).await;
+        create_user(&user.id, &user.username, db_name).await;
     }
 }
 
@@ -70,7 +70,7 @@ async fn read_and_write_user_table_db() {
     let result = get_user(name_s, user_id_s, &test_context.db_name).await;
 
     assert_eq!(user_id_s, result.id.as_str());
-    assert_eq!(name_s, result.name.as_str());
+    assert_eq!(name_s, result.username.as_str());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This is a simple change to rename a column from "name" to "username" in the users table and also make it unique. Closes #33 