### PR TITLE
Run embedded migrations

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -8,6 +8,18 @@ pub mod models;
 pub mod schema;
 pub mod test_context;
 
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/");
+
+pub fn setup_db(db_path: &str) {
+    let mut connection = &mut establish_connection(db_path);
+    
+    connection
+    .run_pending_migrations(MIGRATIONS)
+    .expect("Failed to run migrations");
+    println!("Pending migrations ran successfully");
+}
+
 pub fn establish_connection(db_path: &str) -> SqliteConnection {
     SqliteConnection::establish(db_path)
         .expect(format!("Failed to connect to database at {}", db_path).as_str())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use db::setup_db;
 use frontend_api::{get_game_info, get_leaderboard_data, play_game, AppState};
 use game_dev_api::setup_game_dev_api;
 use tauri::{api::path::local_data_dir, Manager};
@@ -31,6 +32,7 @@ fn main() {
                     .into_os_string()
                     .into_string()
                     .unwrap();
+                setup_db(db_path.as_str());
                 setup_game_dev_api(db_path)
             });
             if cfg!(feature = "autostart") {


### PR DESCRIPTION
### Changes
- [x] Added a db_setup function that embeds the tables in the schema and runs pending migrations.

### How to Test
 - [x] Navigate to the coms-console folder within the [Local Data Dir](https://v1.tauri.app/v1/api/js/path/#localdatadir) and delete local.db if it exists
 - [x] Run `tauri build`
 - [x] Run the packaged application and see if it generates a new local.db

### Testing Considerations
- N/A

Closes #52 