### PR TITLE
Remove unique restrictions on leaderboard table

### DIFF
--- a/src-tauri/migrations/2025-02-21-043342_create_leaderboard/up.sql
+++ b/src-tauri/migrations/2025-02-21-043342_create_leaderboard/up.sql
@@ -5,6 +5,5 @@ CREATE TABLE leaderboard (
   game_id CHAR(32) NOT NULL REFERENCES games(id),
   value_name TEXT NOT NULL,
   value_num DOUBLE NOT NULL DEFAULT 0,
-  time_stamp TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  UNIQUE(user_id, game_id, value_name, value_num)
+  time_stamp TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
 );


### PR DESCRIPTION
## Issue
closes #69

### Major Changes:
- Simply removes unique restrictions on the leaderboard table. Duplicates will be fine because they have different timestamps.

